### PR TITLE
Changed functions to setup instead of wrap

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -424,8 +424,8 @@ function activate_ccache {
     echo "Using C compiler: $(which clang)"
 }
 
-function macos_intel_build_wrap {
-    # Wrap build for single arch x86_64 wheels
+function macos_intel_build_setup {
+    # Setup build for single arch x86_64 wheels
     export PLAT="x86_64"
     export _PYTHON_HOST_PLATFORM="macosx-${MB_PYTHON_OSX_VER}-x86_64"
     export CFLAGS+=" -arch x86_64"
@@ -433,11 +433,10 @@ function macos_intel_build_wrap {
     export ARCHFLAGS+=" -arch x86_64"
     export CPPFLAGS+=" -arch x86_64"
     export LDFLAGS+=" -arch x86_64"
-    $@
 }
 
-function macos_arm64_build_wrap {
-    # Wrap build for single arch arm_64 wheels
+function macos_arm64_build_setup {
+    # Setup build for single arch arm_64 wheels
     export PLAT="arm64"
     export BUILD_PREFIX=/opt/arm64-builds
     sudo mkdir -p $BUILD_PREFIX
@@ -453,7 +452,6 @@ function macos_arm64_build_wrap {
     export LDFLAGS+=" -arch arm64 -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib ${FC_ARM64_LDFLAGS:-}"
     # This would automatically let autoconf know that we are cross compiling for arm64 darwin
     export host_alias="aarch64-apple-darwin20.0.0"
-    $@
 }
 
 function fuse_macos_intel_arm64 {
@@ -477,12 +475,12 @@ function fuse_macos_intel_arm64 {
 
 function wrap_wheel_builder {
     if [[ "${PLAT:-}" == "universal2" ]]; then
-        (macos_intel_build_wrap $@)
+        (macos_intel_build_setup && $@)
         rm -rf *-stamp
-        (macos_arm64_build_wrap $@)
+        (macos_arm64_build_setup && $@)
         fuse_macos_intel_arm64
     elif [[ "${PLAT:-}" == "arm64" ]]; then
-        (macos_arm64_build_wrap $@)
+        (macos_arm64_build_setup && $@)
     else
         $@
     fi

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -480,7 +480,7 @@ function wrap_wheel_builder {
         (macos_intel_build_wrap $@)
         rm -rf *-stamp
         (macos_arm64_build_wrap $@)
-        fuse_macos_intel_arm64 $@
+        fuse_macos_intel_arm64
     elif [[ "${PLAT:-}" == "arm64" ]]; then
         (macos_arm64_build_wrap $@)
     else


### PR DESCRIPTION
This is sort of just stylistic, so feel free to decline if you want - looking at `macos_intel_build_wrap` and `macos_arm64_build_wrap`, they don't need to wrap. They could just be run before.

Also includes https://github.com/matthew-brett/multibuild/pull/383/files#r560766796